### PR TITLE
update the docker image to plucky

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,22 +11,22 @@ RUN docker/build.sh
 # ==================================================================================================
 # Final image
 
-FROM ubuntu:mantic
+FROM ubuntu:plucky
 LABEL maintainer="Sergey Alexandrovich <darthsim@gmail.com>"
 
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
-    bash \
-    ca-certificates \
-    libstdc++6 \
-    liblzma5 \
-    libzstd1 \
-    fontconfig-config \
-    fonts-dejavu-core \
-    media-types \
-    libjemalloc2 \
-    libtcmalloc-minimal4 \
+  bash \
+  ca-certificates \
+  libstdc++6 \
+  liblzma5 \
+  libzstd1 \
+  fontconfig-config \
+  fonts-dejavu-core \
+  media-types \
+  libjemalloc2 \
+  libtcmalloc-minimal4 \
   && ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so \
   && ln -s /usr/lib/$(uname -m)-linux-gnu/libtcmalloc_minimal.so.4 /usr/local/lib/libtcmalloc_minimal.so \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I tried to build the imgproxy image, and it kept failing and displaying the errors below.
```
1.014 Ign:1 http://ports.ubuntu.com/ubuntu-ports mantic InRelease
1.484 Ign:2 http://ports.ubuntu.com/ubuntu-ports mantic-updates InRelease
1.986 Ign:3 http://ports.ubuntu.com/ubuntu-ports mantic-backports InRelease
2.262 Ign:4 http://ports.ubuntu.com/ubuntu-ports mantic-security InRelease
2.558 Err:5 http://ports.ubuntu.com/ubuntu-ports mantic Release
2.558   404  Not Found [IP: 185.125.190.39 80]
3.031 Err:6 http://ports.ubuntu.com/ubuntu-ports mantic-updates Release
3.031   404  Not Found [IP: 185.125.190.39 80]
3.336 Err:7 http://ports.ubuntu.com/ubuntu-ports mantic-backports Release
3.336   404  Not Found [IP: 185.125.190.39 80]
3.653 Err:8 http://ports.ubuntu.com/ubuntu-ports mantic-security Release
3.653   404  Not Found [IP: 185.125.190.39 80]
```
The reason for this seems to be that [`Ubuntu 23.10 (Mantic Minotaur) reached End of Life on July 11, 2024`](https://fridge.ubuntu.com/2024/07/17/ubuntu-23-10-mantic-minotaur-reached-end-of-life-on-july-11-2024/)
I updated the ubuntu image version to plucky, and now it builds successfully on my machine.